### PR TITLE
using old domain works partly

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,6 +9,7 @@ This code is inspired by a project for SmartThingsHub, see `here <https://github
 
 Warmup Plc was not involved in the creation of this
 software and has not sanctioned or endorsed it in any way.
+4IE is a registered trademark of Warmup Plc.
 
 License
 =======
@@ -22,10 +23,24 @@ The library is primary intended to interface the 4IE with home assistant, but ma
 
 Home Assistant
 ---------------
+
 To setup this component, you need to register to warmup first.
 see https://my.warmup.com/login
 
-Then copy the folder `warmup_cc <https://github.com/alex-0103/warmup4IE/blob/master/warmup_cc>`_ to your "*custom_components*" folder in your "*config*" dir.
+Then copy the contents of the warmup_cc subfolder into custom_components 
+in your HA **config** folder, e.g.:
+
+.. code-block:: sh
+
+  cd path/to/your/config
+  # remove any previous version
+  rm -r ./custom_components/warmup_cc 2>/dev/null
+  git clone https://github.com/ha-warmup/warmup.git /tmp/warmup
+  mkdir -p ./custom_components/warmup_cc
+  cp -r /tmp/warmup/warmup_cc/* ./custom_components/warmup_cc
+  # clean up
+  rm -rf /tmp/warmup/
+
 
 Then add to your
 configuration.yaml:
@@ -34,17 +49,11 @@ configuration.yaml:
 
   climate:
     - platform: warmup_cc
-      name: YOUR_DESCRIPTION
       username: YOUR_E_MAIL_ADDRESS
       password: YOUR_PASSWORD
-      location: YOUR_LOCATION_NAME
-      room: YOUR_ROOM_NAME
 
-* **name** (optional): the description of the device, as seen by the user in the front end
 * **username** (required): the username used to login to the warmup web site
 * **password** (required): the password used to login to the warmup web site; may be moved to the secrets.yaml file. See `secrets <https://www.home-assistant.io/docs/configuration/secrets/>`_
-* **location** (required): the location name used in the warmup web site
-* **room** (required): the room name of the device used in the warmup web site
 
 After restarting home assistant, the component will be loaded automatically.
 
@@ -133,3 +142,9 @@ Release Notes
     - override_duration
     - sleep_temperature
     - override_duration_mins
+
+0.1.7
+-----
+
+- initialise using new **services** standards https://developers.home-assistant.io/docs/en/dev_101_services.html 
+

--- a/warmup_cc/climate.py
+++ b/warmup_cc/climate.py
@@ -33,7 +33,7 @@ import homeassistant.helpers.config_validation as cv
 from homeassistant.util import Throttle
 from homeassistant.util.temperature import convert as convert_temperature
 
-DOMAIN = "warmup"
+DOMAIN = "warmup_cc"
 CONFIG_SCHEMA = vol.Schema(
     {
         DOMAIN: vol.Schema(


### PR DESCRIPTION
For now this minor change allows the custom component functionality to work partly.
In my instance this component registers with HA and connects to mywarmup to obtain device information into a climate.<room> entity