### PR TITLE
Add version and issue tracker to manifest.json

### DIFF
--- a/warmup_cc/manifest.json
+++ b/warmup_cc/manifest.json
@@ -1,7 +1,9 @@
 {
-  "domain": "warmup_cc",
+  "domain": "warmup",
   "name": "Warmup",
+  "version": "0.1.6",
   "documentation": "https://www.home-assistant.io/components/warmup",
+  "issue_tracker": "https://github.com/ha-warmup/warmup/issues/",
   "dependencies": [],
   "codeowners": [],
   "requirements": []


### PR DESCRIPTION
Add version to manifest.json, so Home Assistant 2021.6.x won't prevent warmup from starting.

- Changed domain to match the custom component name.
- Added issue_tracker to tie back to this repo.

Note: the installation instructions need to be updated to not put the custom component in `warmup_cc` instead of `warmup`.  It should match the name of the custom component. This is somewhat of an old issue.  

Fixes #25