### PR TITLE
Incorporate recent bugfixes as formal release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ Recent features from development that have not been formally released yet:
 
 ### Added
 
-* 9d4d24d some additions notes and suggestions for project contributors
+* 
 
 ### Changed
 
@@ -24,7 +24,7 @@ Recent features from development that have not been formally released yet:
 
 ### Fixed
 
-* 418503e Bumped version in manifest.json (missed during 2023.3.19 release)
+* 
 
 ### Deprecated
 
@@ -33,6 +33,21 @@ Recent features from development that have not been formally released yet:
 ### Removed
 
 * 
+
+
+## 2023.3.22
+
+This is a bugfix release. The previous release had a broken HACS manifest.
+
+### Added
+
+* 9d4d24d some additions notes and suggestions for project contributors
+* d9733d9 Tip when changing config, plus slight re-org, in README.md
+
+### Fixed
+
+* 418503e Bumped version in manifest.json (missed during 2023.3.19 release)
+
 
 
 ## 2023.3.19

--- a/README.md
+++ b/README.md
@@ -100,7 +100,10 @@ you should see the following warning in the logs:
 This is a positive sign, as it means 
 the custom component has been successfully loaded. Great! - now carry on.
 
-#### Add the warmup platform manually via YAML
+
+## Configuration
+
+### Add the warmup platform manually via YAML
 
 Then add to your configuration.yaml:
 
@@ -120,7 +123,32 @@ climate:
 After restarting home assistant, the component will be loaded
 automatically.
 
+#### Tip when changing config
+
+If you are winding up having to do multiple restarts because Home Assistant won't shutdown with the updated config file (because when it checks the config file, integration warmup not found) you can get around that by using the CLI command `ha core restart`.    
+
+Alternatively, with the menu restructuring, the menu entry for _Stop Server_ isn't accessible.  However you can use the keyboard short cut 'c' and type restart to find that choice. Once the server has stopped you can move the config entry in and do a `ha core start` 
+
+
+### Add your devices to the dashboard
+
+Our wiki has some [ideas on how to configure warmup
+devices](https://github.com/ha-warmup/warmup/wiki/Configuration-ideas)
+in your Home Assistant instance.
+
+
+## Other installation types
+
+We do **not currently** have instructions for using this software as 
+a _Custom repository_ for **Home Assistant Operating System** (HAOS) 
+or **Home Assistant Container** deployments, 
+but you are welcome to use our issue tracker 
+to discuss any potential improvements to this project. 
+
+
 ### Standalone
+
+_OLD instructions_
 
 You may install the library via pip using
 
@@ -137,23 +165,6 @@ After that, import the library, and away you go.
 >>> device = warmup.get_device_by_name(\"Underfloor\") 
 >>> device.get_current_temperature()
 ```
-
-### Other installation types
-
-We do **not currently** have instructions for using this software as 
-a _Custom repository_ for **Home Assistant Operating System** (HAOS) 
-or **Home Assistant Container** deployments, 
-but you are welcome to use our issue tracker 
-to discuss any potential improvements to this project. 
-
-
-## Configuration
-
-### Add your devices to the dashboard
-
-Our wiki has some [ideas on how to configure warmup
-devices](https://github.com/ha-warmup/warmup/wiki/Configuration-ideas)
-in your Home Assistant instance.
 
 
 

--- a/custom_components/warmup/manifest.json
+++ b/custom_components/warmup/manifest.json
@@ -8,5 +8,5 @@
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/ha-warmup/warmup/issues/",
   "requirements": [],
-  "version": "2023.03.19"
+  "version": "2023.03.22"
 }


### PR DESCRIPTION
Now the integration shows in HACS, we need the manifest updates to be included in a Release for them to be generally available, so this bumps the Release